### PR TITLE
Fix: Using chainguard Redis image to remove vulnerabilities

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '3.8'
-
 services:
   redis:
-    image: redis:alpine
+    image: johnmonteir0/chainguard-redis:latest
     ports:
       - "6379:6379"
 


### PR DESCRIPTION
- Using chainguard image for Redis
- Signing image with Cosign
- Remove compose version